### PR TITLE
Add "take" command, which allows to remove keys from players.

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/commands/CommandEcoCrates.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/commands/CommandEcoCrates.kt
@@ -21,6 +21,7 @@ class CommandEcoCrates(plugin: EcoPlugin) : PluginCommand(
             .addSubcommand(CommandResetWins(plugin))
             .addSubcommand(CommandConvert(plugin))
             .addSubcommand(CommandGiveall(plugin))
+            .addSubcommand(CommandTake(plugin))
     }
 
     override fun onExecute(sender: CommandSender, args: List<String>) {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/commands/CommandTake.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/commands/CommandTake.kt
@@ -1,0 +1,129 @@
+package com.willfp.ecocrates.commands
+
+import com.willfp.eco.core.EcoPlugin
+import com.willfp.eco.core.command.impl.Subcommand
+import com.willfp.eco.util.savedDisplayName
+import com.willfp.ecocrates.crate.Crates
+import org.bukkit.Bukkit
+import org.bukkit.command.CommandSender
+import org.bukkit.util.StringUtil
+
+class CommandTake(plugin: EcoPlugin) : Subcommand(
+    plugin,
+    "take",
+    "ecocrates.command.take",
+    false
+) {
+    override fun onExecute(sender: CommandSender, args: List<String>) {
+        if (args.isEmpty()) {
+            sender.sendMessage(plugin.langYml.getMessage("must-specify-player"))
+            return
+        }
+
+        val player = Bukkit.getPlayer(args[0])
+
+        if (player == null) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-player"))
+            return
+        }
+
+        if (args.size < 2) {
+            sender.sendMessage("must-specify-crate")
+            return
+        }
+
+        val crate = Crates.getByID(args[1])
+
+        if(crate == null) {
+            sender.sendMessage(plugin.langYml.getMessage("invalid-crate"))
+            return
+        }
+
+        val physical = args.getOrNull(2)?.equals("physical", ignoreCase = true) == true
+
+        val takeAmount = args.getOrNull(3)?.toIntOrNull() ?: 1
+
+        var taken = false
+        if (physical) {
+            for (item in player.inventory.contents) {
+                if (item != null && crate.key.matches(item)) {
+                    if (item.amount >= takeAmount) {
+                        item.amount = item.amount - takeAmount
+                        taken = true
+                        break
+                    }
+                }
+            }
+        } else {
+            if (crate.getVirtualKeys(player) >= takeAmount) {
+                crate.adjustVirtualKeys(player, takeAmount * -1)
+                taken = true
+            }
+        }
+
+        if (taken) {
+            sender.sendMessage(
+                plugin.langYml.getMessage("took-keys")
+                    .replace("%amount%", takeAmount.toString())
+                    .replace("%crate%", crate.name)
+                    .replace("%user%", player.savedDisplayName)
+            )
+        } else {
+            sender.sendMessage(
+                plugin.langYml.getMessage("not-enough-took-keys")
+                    .replace("%crate%", crate.name)
+                    .replace("%user%", player.savedDisplayName)
+            )
+        }
+    }
+
+    override fun tabComplete(sender: CommandSender, args: List<String>): List<String> {
+        val completions = mutableListOf<String>()
+
+        if (args.isEmpty()){
+            return Crates.values().map { it.id }
+        }
+
+        if (args.size == 1) {
+            StringUtil.copyPartialMatches(
+                args[0],
+                Bukkit.getOnlinePlayers().map { it.name },
+                completions
+            )
+
+            return completions
+        }
+
+        if (args.size == 2) {
+            StringUtil.copyPartialMatches(
+                args[1],
+                Crates.values().map { it.id },
+                completions
+            )
+
+            return completions
+        }
+
+        if (args.size == 3) {
+            StringUtil.copyPartialMatches(
+                args[2],
+                listOf("physical", "virtual"),
+                completions
+            )
+
+            return completions
+        }
+
+        if (args.size == 4) {
+            StringUtil.copyPartialMatches(
+                args[3],
+                listOf("1", "2", "3", "4", "5", "10"),
+                completions
+            )
+
+            return completions
+        }
+
+        return emptyList()
+    }
+}

--- a/eco-core/core-plugin/src/main/resources/lang.yml
+++ b/eco-core/core-plugin/src/main/resources/lang.yml
@@ -12,6 +12,8 @@ messages:
   invalid-player: "&cUnknown player!"
   gave-keys: "Gave %amount%&f %crate%&f key(s) to %user%&f!"
   gave-keys-all: "Gave %amount%&f %crate%&f key(s) to all online players!"
+  took-keys: "Took %amount%&f %crate%&f key(s) from %user%&f!"
+  not-enough-took-keys: "&c%user%&f has not enough %crate% key(s) to take!"
   must-target-block: "&cYou must be looking at a block!"
   set-block-as-crate: "Set block to be a crate!"
   removed-crate: "Removed crate!"

--- a/eco-core/core-plugin/src/main/resources/plugin.yml
+++ b/eco-core/core-plugin/src/main/resources/plugin.yml
@@ -32,6 +32,7 @@ permissions:
       ecocrates.command.reload: true
       ecocrates.command.ecocrates: true
       ecocrates.command.give: true
+      ecocrates.command.take: true
       ecocrates.command.open: true
       ecocrates.command.open.others: true
       ecocrates.command.preview: true
@@ -58,6 +59,9 @@ permissions:
     default: op
   ecocrates.command.giveall:
     description: Allows giving all players keys
+    default: op
+  ecocrates.command.take:
+    description: Allows taking players keys
     default: op
   ecocrates.command.open:
     description: Allows opening crates with /ecocrates open


### PR DESCRIPTION
First time doing something in minecraft and kotlin. I switched from another plugin to this one, and this feature was missing here, so tried to do it by myself.

With this command we can create "keys exchangers" (i.e take from player 5 keys of crate X, and give him 1 key of crate Y)