### PR TITLE
Fix potential array index out of bounds in RollCSGO

### DIFF
--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
@@ -78,7 +78,7 @@ class RollCSGO private constructor(
                     ItemStack(Material.AIR)
                 ) {
                     setUpdater { _, _, _ ->
-                        display[(9 - i) + scroll].getDisplay(player, crate)
+                        display[((9 - i) + scroll).coerceAtMost(display.lastIndex)].getDisplay(player, crate)
                     }
                 }
             )
@@ -120,7 +120,7 @@ class RollCSGO private constructor(
     }
 
     override fun shouldContinueTicking(tick: Int): Boolean {
-        return scroll <= scrollTimes
+        return scroll < scrollTimes
     }
 
     override fun onFinish() {

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
@@ -94,7 +94,7 @@ class RollCSGO private constructor(
     }
 
     override fun tick(tick: Int) {
-        val currentDelay = delays[scroll]
+        val currentDelay = delays[scroll.coerceAtMost(delays.lastIndex)]
 
         if (ticksSinceLastScroll % currentDelay == 0) {
             ticksSinceLastScroll = 0

--- a/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
+++ b/eco-core/core-plugin/src/main/kotlin/com/willfp/ecocrates/crate/roll/RollCSGO.kt
@@ -94,20 +94,26 @@ class RollCSGO private constructor(
     }
 
     override fun tick(tick: Int) {
-        val currentDelay = delays[scroll.coerceAtMost(delays.lastIndex)]
+        if (scroll > scrollTimes) {
+            return
+        }
+
+        val currentDelay = delays[scroll]
 
         if (ticksSinceLastScroll % currentDelay == 0) {
             ticksSinceLastScroll = 0
             scroll++
 
-            gui.refresh(player)
+            if (scroll <= scrollTimes) {
+                gui.refresh(player)
 
-            player.playSound(
-                player.location,
-                Sound.BLOCK_STONE_BUTTON_CLICK_ON,
-                1.0f,
-                1.0f
-            )
+                player.playSound(
+                    player.location,
+                    Sound.BLOCK_STONE_BUTTON_CLICK_ON,
+                    1.0f,
+                    1.0f
+                )
+            }
         }
 
         ticksSinceLastScroll++


### PR DESCRIPTION
## Summary
- Guard `delays[scroll]` access with `coerceAtMost(delays.lastIndex)` to prevent `ArrayIndexOutOfBoundsException` on edge case scroll values (e.g. when `scrollTimes` config is very low)

## Test plan
- [ ] Set `rolls.csgo.scrolls` to 0 and 1 in config, open a CSGO-roll crate, verify no crash
- [ ] Verify normal scroll values still animate correctly