### PR TITLE
fix: Admonition format

### DIFF
--- a/documentation/ecocrates/how-to-make-a-crate.md
+++ b/documentation/ecocrates/how-to-make-a-crate.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "How to make a Crate"
 sidebar_position: 3
 ---
@@ -178,7 +178,7 @@ placed: # Options for physically placed crates
 ```
 
 #### The Open and Finish Effects Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the crate. You can configure effects, conditions, and filters to run when the crate is opened or when it finishes rolling.
 

--- a/documentation/ecocrates/how-to-make-a-reward.md
+++ b/documentation/ecocrates/how-to-make-a-reward.md
@@ -1,4 +1,4 @@
----
+﻿---
 title: "How to make a Reward"
 sidebar_position: 1
 ---
@@ -42,7 +42,7 @@ display:
 ## Understanding the Sections
 
 #### The Reward Basics Section
-:::dangerEffects Section
+:::danger Effects Section
 
 The effects section is the core functionality of the crate reward. You can configure effects, conditions, and filters to run when the crate reward is won.
 


### PR DESCRIPTION
Fixes missing space between admonition type and title in documentation (e.g. `:::dangerEffects Section` → `:::danger Effects Section`).